### PR TITLE
Missed "else" in property setter delegate.

### DIFF
--- a/Fody/Cauldron.BasicInterceptors/Weaver_Property.cs
+++ b/Fody/Cauldron.BasicInterceptors/Weaver_Property.cs
@@ -518,8 +518,8 @@ public static class Weaver_Property
             // Otherwise if the property is not a value type and nullable
             else if (!propertyType.IsValueType || propertyType.IsNullable || propertyType.IsArray)
                 CodeMe<CoderBase>(
-                    field => setterCode.SetValue(field, null),
-                    property => setterCode.Call(property.Setter, null));
+                    field => setterCode.SetValue(field, null).Return(),
+                    property => setterCode.Call(property.Setter, null).Return());
             else // otherwise... throw an exception
                 then.ThrowNew(typeof(NotSupportedException), "Value types does not accept null values.");
 

--- a/UnitTests/Shared/MainTests/BasicInterceptors/Property_Interceptor_Code_Validation_Tests.cs
+++ b/UnitTests/Shared/MainTests/BasicInterceptors/Property_Interceptor_Code_Validation_Tests.cs
@@ -107,6 +107,9 @@ namespace UnitTests.BasicInterceptors
         [TestPropertyInterceptor]
         public long ValueTypePropertyPrivateSetter { get; private set; }
 
+        [TestPropertyInterceptor]
+        public int? NullableProperty { get; set; }
+
         [TestMethod]
         public void Array_Property_Setter()
         {
@@ -196,6 +199,19 @@ namespace UnitTests.BasicInterceptors
 
             this.ValueTypeProperty = 30;
             Assert.AreEqual(9999, this.ValueTypeProperty);
+        }
+
+        [TestMethod]
+        public void Nullable_Property()
+        {
+            this.NullableProperty = 113;
+            Assert.IsNull(this.NullableProperty);
+
+            this.NullableProperty = 121;
+            Assert.AreEqual(121, this.NullableProperty);
+
+            this.NullableProperty = null;
+            Assert.IsNull(this.NullableProperty);
         }
 
         private List<long> Blub()

--- a/UnitTests/Shared/TestInterceptors/TestPropertyInterceptorAttribute.cs
+++ b/UnitTests/Shared/TestInterceptors/TestPropertyInterceptorAttribute.cs
@@ -23,6 +23,9 @@ namespace UnitTest_InterceptorsForTest
 
             if (Comparer.Equals(value, (double)66))
                 propertyInterceptionInfo.SetValue(78344.8f);
+
+            if (Comparer.Equals(value, (int)113))
+                propertyInterceptionInfo.SetValue(null);
         }
 
         public bool OnSet(PropertyInterceptionInfo propertyInterceptionInfo, object oldValue, object newValue)


### PR DESCRIPTION
I have nullable property
```
[MyAttribute]
public int? NullableProperty { get; set; }
```
with simple attribute
```
public class MyAttribute : Attribute, IPropertyInterceptor
{
    public void OnGet(PropertyInterceptionInfo propertyInterceptionInfo, object value)
    {
        int? newValue = CalculateValue();
        propertyInterceptionInfo.SetValue(newValue);
    }
    ...
}
```
When the newValue is null and I set it to propertyInterceptionInfo, then the NullableProperty returns 0 instead of null. This is because the "else" is missing in the generated method, after the first "if"
```
private void \u003CNullableProperty\u003Em__setterMethod([In] object obj0)
{
    if (obj0 == null)
        this.\u003CNullableProperty\u003Ek__BackingField = new int?();
    if (obj0 is int?)
        this.\u003CNullableProperty\u003Ek__BackingField = new int?(Convert.ToInt32(obj0));
    else
        this.\u003CNullableProperty\u003Ek__BackingField = new int?(Convert.ToInt32(obj0));
}
```
