### PR TITLE
Problem with async methods in generic class fixed.

### DIFF
--- a/Fody/Cauldron.Interception.Cecilator/Extension.cs
+++ b/Fody/Cauldron.Interception.Cecilator/Extension.cs
@@ -904,6 +904,12 @@ namespace Cauldron.Interception.Cecilator
             {
                 var declaringType = new GenericInstanceType(field.DeclaringType.typeDefinition);
 
+                if (method.methodReference.DeclaringType.IsGenericInstance && method.methodReference.DeclaringType is GenericInstanceType genericInstanceType)
+                {
+                    foreach (var parameter in genericInstanceType.GenericArguments)
+                        declaringType.GenericArguments.Add(parameter);
+                }
+
                 foreach (var parameter in method.methodReference.GenericParameters)
                     declaringType.GenericArguments.Add(parameter);
 
@@ -1442,7 +1448,7 @@ namespace Cauldron.Interception.Cecilator
             };
 
             foreach (var parameter in self.Parameters)
-                reference.Parameters.Add(new ParameterDefinition(parameter.ParameterType));
+                reference.Parameters.Add(new ParameterDefinition(parameter.ParameterType) { Name = parameter.Name });
 
             foreach (var generic_parameter in self.GenericParameters)
                 reference.GenericParameters.Add(new GenericParameter(generic_parameter.Name, reference));

--- a/UnitTests/Shared/MainTests/BasicInterceptors/Method_Interceptor_Code_Validation_Tests.cs
+++ b/UnitTests/Shared/MainTests/BasicInterceptors/Method_Interceptor_Code_Validation_Tests.cs
@@ -767,4 +767,32 @@ namespace UnitTests.BasicInterceptors
             return 3434;
         }
     }
+
+    [TestClass]
+    public class Method_Interceptor_Code_Validation_Generic_Tests<T>
+    {
+        [TestMethodInterceptor]
+        public async Task Async_Method()
+        {
+            await Task.Run(() => default(T));
+        }
+
+        [TestMethodInterceptor]
+        public async Task<T> Generic_Async_Method()
+        {
+            return await Task.Run(() => default(T));
+        }
+
+        [TestMethodInterceptor]
+        public async Task<T> Generic_Async_Method_With_Parameters(int a, string b)
+        {
+            return await Task.Run(() => default(T));
+        }
+
+        [TestMethodInterceptor]
+        public async Task<T> Generic_Async_Method_With_Generic_Parameters<TParam1, TParam2>(TParam1 p1, int a, TParam2 p2, string b)
+        {
+            return await Task.Run(() => default(T));
+        }
+    }
 }

--- a/UnitTests/Shared/MainTests/BasicInterceptors/SimpleMethod_Interceptor_Code_Validation_Tests.cs
+++ b/UnitTests/Shared/MainTests/BasicInterceptors/SimpleMethod_Interceptor_Code_Validation_Tests.cs
@@ -93,4 +93,32 @@ namespace UnitTests.BasicInterceptors
             return 44;
         }
     }
+
+    [TestClass]
+    public class SimpleMethod_Interceptor_Code_Validation_Generic_Tests<T>
+    {
+        [SimpleInterceptor]
+        public async Task Async_Method()
+        {
+            await Task.Run(() => default(T));
+        }
+
+        [SimpleInterceptor]
+        public async Task<T> Generic_Async_Method()
+        {
+            return await Task.Run(() => default(T));
+        }
+
+        [SimpleInterceptor]
+        public async Task<T> Generic_Async_Method_With_Parameters(int a, string b)
+        {
+            return await Task.Run(() => default(T));
+        }
+
+        [SimpleInterceptor]
+        public async Task<T> Generic_Async_Method_With_Generic_Parameters<TParam1, TParam2>(TParam1 p1, int a, TParam2 p2, string b)
+        {
+            return await Task.Run(() => default(T));
+        }
+    }
 }


### PR DESCRIPTION
There are two problems with interseption async methods in generic classes.
The first - the missed generic argument in the state machine's field, the second - the empty names of fields and parameters.
Source code:
```
public class SimpleMethodInterceptorTest<T>
{
    [TestMethodInterceptor]
    public async Task<T> AsyncMethodWithParameters(int a, string b)
    {
        return await Task.Run(() => default(T));
    }
}
```
Generated code:
```
...
[AsyncStateMachine(typeof (SimpleMethodInterceptorTest<>.\u003CAsyncMethodWithParameters\u003Ed__0))]
[DebuggerStepThrough]
public Task<T> AsyncMethodWithParameters(int a, string b)
{
  if (this.\u003CAsyncMethodWithParameters\u003E_fwelbpjc2mc1 == null)
    this.\u003CAsyncMethodWithParameters\u003E_fwelbpjc2mc1 = (IMethodInterceptor) new TestMethodInterceptorAttribute();
  SimpleMethodInterceptorTest<T>.\u003CAsyncMethodWithParameters\u003Ed__0 stateMachine = new SimpleMethodInterceptorTest<T>.\u003CAsyncMethodWithParameters\u003Ed__0();
  stateMachine.\u003C\u003E4__this = this;
  stateMachine.a = a;
  stateMachine.b = b;
  stateMachine.\u003C\u003Et__builder = AsyncTaskMethodBuilder<T>.Create();
  stateMachine.\u003C\u003E1__state = -1;
  ((SimpleMethodInterceptorTest<>.\u003CAsyncMethodWithParameters\u003Ed__0) stateMachine). = a;
  ((SimpleMethodInterceptorTest<>.\u003CAsyncMethodWithParameters\u003Ed__0) stateMachine).\u003CAsyncMethodWithParameters\u003E_fwelbpjc2mc1 = this.\u003CAsyncMethodWithParameters\u003E_fwelbpjc2mc1; // the first problem
  stateMachine.\u003C\u003Et__builder.Start<SimpleMethodInterceptorTest<T>.\u003CAsyncMethodWithParameters\u003Ed__0>(ref stateMachine);
  return stateMachine.\u003C\u003Et__builder.Task;
}
...
[CompilerGenerated]
private sealed class \u003CAsyncMethodWithParameters\u003Ed__0 : IAsyncStateMachine
{
  public int \u003C\u003E1__state;
  public AsyncTaskMethodBuilder<T> \u003C\u003Et__builder;
  public int a;
  public string b;
  public SimpleMethodInterceptorTest<T> \u003C\u003E4__this;
  private T \u003C\u003Es__1;
  private TaskAwaiter<T> \u003C\u003Eu__1;
  public IMethodInterceptor \u003CAsyncMethodWithParameters\u003E_fwelbpjc2mc1;
  public int ; // the second problem

  public \u003CAsyncMethodWithParameters\u003Ed__0()
  {
    base.\u002Ector();
  }

  void IAsyncStateMachine.MoveNext()
  {
    int num1 = this.\u003C\u003E1__state;
    T s1;
    try
    {
      object[] values = new object[2]
      {
        (object) this.,
        (object) this.
      }; // the second problem
...
```